### PR TITLE
Try ubuntu 20.04 instead of 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ name: test
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: shogo82148/actions-setup-perl@v1


### PR DESCRIPTION
The ubuntu-18.04 environment fails when installing some dependencies for latexml. Let's try with ubuntu-20.04 instead.