### PR TITLE
Add support for embedding PDF export of Google slideset

### DIFF
--- a/sample-fancy.html
+++ b/sample-fancy.html
@@ -218,7 +218,7 @@
 
 <address>Minutes manually created (not a transcript), formatted by <a
 href="https://w3c.github.io/scribe2/scribedoc.html"
->scribe.perl</a> version 228 (Tue Jul 23 12:57:54 2024 UTC).</address>
+>scribe.perl</a> version google-slides-232 (Wed Sep 18 23:49:16 2024 UTC).</address>
 
 <div class=diagnostics>
 <h2>Diagnostics</h2>

--- a/sample-member.html
+++ b/sample-member.html
@@ -240,7 +240,7 @@ Web and TV IG - Media APIs TF</h1>
 
 <address>Minutes manually created (not a transcript), formatted by <a
 href="https://w3c.github.io/scribe2/scribedoc.html"
->scribe.perl</a> version 228 (Tue Jul 23 12:57:54 2024 UTC).</address>
+>scribe.perl</a> version google-slides-232 (Wed Sep 18 23:49:16 2024 UTC).</address>
 
 <div class=diagnostics>
 <h2>Diagnostics</h2>

--- a/sample-public.html
+++ b/sample-public.html
@@ -135,7 +135,7 @@
 
 <address>Minutes manually created (not a transcript), formatted by <a
 href="https://w3c.github.io/scribe2/scribedoc.html"
->scribe.perl</a> version 228 (Tue Jul 23 12:57:54 2024 UTC).</address>
+>scribe.perl</a> version google-slides-232 (Wed Sep 18 23:49:16 2024 UTC).</address>
 
 <div class=diagnostics>
 <h2>Diagnostics</h2>

--- a/sample-slides.html
+++ b/sample-slides.html
@@ -10,7 +10,7 @@
 <link rel="alternate stylesheet" type="text/css" title="2004" href="https://www.w3.org/2004/02/minutes-style.css">
 <link rel="alternate stylesheet" type="text/css" title="Fancy" href="https://www.w3.org/StyleSheets/scribe2/fancy.css">
 <link rel="alternate stylesheet" type="text/css" title="Typewriter" href="https://www.w3.org/StyleSheets/scribe2/tt-member.css">
-<script type=module src="https://w3c.github.io/i-slide/i-slide-2.js?selector=a.islide"></script>
+<script type=module src="https://w3c.github.io/i-slide/i-slide.js?selector=a.islide"></script>
 </head>
 
 <body>
@@ -60,9 +60,9 @@
 <span id=x031>… in the context of ML, reaching interop is not necessarily easy given the variety of underlying hardware</span><br>
 <span id=x032>… Chai is involved in Microsoft DirectML and has experience in this space</span></p>
 <p id=x033 class=summary>Slideset: <a href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf">https://<wbr>lists.w3.org/<wbr>Archives/<wbr>Public/<wbr>www-archive/<wbr>2021Oct/<wbr>att-0017/<wbr>Conformance_Testing_of_Machine_Learning_API.pdf</a></p>
-<p id=x034 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=1">[Slide 1]</a></p>
+<p id=x034 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=1">[Slide 1]</a></p>
 <p id=x035 class="phone s02"><cite>Chai:</cite> conformance testing of ML APIs is quite important</p>
-<p id=x036 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=2">[Slide 2]</a></p>
+<p id=x036 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=2">[Slide 2]</a></p>
 <p id=x050 class="phone s02"><cite>chai:</cite> the problems can be categorized into 3 categories:<br>
 <span id=x051>… the ML models need to run on a wide variety of specialized hardware</span><br>
 <span id=x052>… my work with DirectML is at the lowest level before the hardware in the windows OS</span><br>
@@ -74,11 +74,11 @@
 <span id=x058>… FP calculation with real numbers accumulate errors as you progress in the computation - that's a fact of life</span><br>
 <span id=x059>… there are trimming problems which create challenges in testing the results of ML API across hardware</span><br>
 <span id=x060>… this is a daily issue in my work testing Direct ML</span></p>
-<p id=x061 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=3">[Slide 3]</a></p>
+<p id=x061 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=3">[Slide 3]</a></p>
 <p id=x064 class="phone s02"><cite>Chai:</cite> Karen Zack's Animals vs Food prompted a an actual AI challenge<br>
 <span id=x065>… humans don't have too much difficulty doing the difference, but while many models are able to perform, they tend to give results with some level of uncertainty</span><br>
 <span id=x066>… showing the importance of reliability across hardware</span></p>
-<p id=x067 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=4">[Slide 4]</a></p>
+<p id=x067 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=4">[Slide 4]</a></p>
 <p id=x077 class="phone s02"><cite>Chai:</cite> when we run the results of ML models, there are 4 groups of variability<br>
 <span id=x078>… the most obvious one is precision differences - half vs double precision will give different results</span><br>
 <span id=x079>… most models run with single precision float, but many will run with half</span><br>
@@ -89,7 +89,7 @@
 <span id=x084>… Finally, there is numerical variability - even on the same hardware, running floating point calculation, there may be slight difference across runs</span><br>
 <span id=x085>… and that can be amplified by issues of lossy conversion between floating point to fixed point,</span><br>
 <span id=x086>… these issues compound one with another, so there is no guarantee of reproducible results</span></p>
-<p id=x087 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=5">[Slide 5]</a></p>
+<p id=x087 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=5">[Slide 5]</a></p>
 <p id=x098 class="phone s02"><cite>Chai:</cite> how do we deal with that in testing?<br>
 <span id=x099>… Many test frameworks use fuzzy comparison that provides an upper boundary (called epsilon) to an acceptable margin of differences</span><br>
 <span id=x100>… the problem of that approach in ML is that it doesn't deal with the source of variabilities we identified</span><br>
@@ -98,13 +98,13 @@
 <span id=x103>… a comparison between the binary representation of different floating point values, applicable to any float point format</span><br>
 <span id=x104>… Using ULP comparison removes the uncertainty on numerical differences</span><br>
 <span id=x105>… it also mitigates the hardware varaibility in terms of architectural differences because it compares the representations</span></p>
-<p id=x106 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=6">[Slide 6]</a></p>
+<p id=x106 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=6">[Slide 6]</a></p>
 <p id=x112 class="phone s02"><cite>Chai:</cite> this piece of code illustrates the ULP comparison<br>
 <span id=x113>… the compare function convert the floating point number into a bitwise value that is used to calculate the difference and how much ULP that represents</span><br>
 <span id=x114>… e.g. here, only a difference of 1 ULP is deemed acceptable</span><br>
 <span id=x115>… We use ULP to test DirectML</span><br>
 <span id=x116>… the actual floating point values from the tests are never the same</span></p>
-<p id=x117 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=7">[Slide 7]</a></p>
+<p id=x117 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=7">[Slide 7]</a></p>
 <p id=x124 class="phone s02"><cite>Chai:</cite> to make the comparison, you need to define a point of reference, which we call the baseline<br>
 <span id=x125>… the baseline is determined by the best known result for the computation, the ideal result</span><br>
 <span id=x126>… this serves as a stable invariant</span><br>
@@ -112,7 +112,7 @@
 <span id=x128>… we use that as our ideal baseline</span><br>
 <span id=x129>… we then define the tolerance in terms of ULP - the acceptable difference between what is and what should be (the baseline)</span><br>
 <span id=x130>… the key ideas here are #1 use the baseline, #2 define tolerance in terms of ULP</span></p>
-<p id=x131 class=summary><a class=islide href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=8">[Slide 8]</a></p>
+<p id=x131 class=summary><a class=islide data-islide-srcref="" href="https://lists.w3.org/Archives/Public/www-archive/2021Oct/att-0017/Conformance_Testing_of_Machine_Learning_API.pdf#page=8">[Slide 8]</a></p>
 <p id=x141 class="phone s02"><cite>Chai:</cite> the strategy of constructing tests can be summarized in 5 recommendations:<br>
 <span id=x142>… we recommend testing both the model and the kernels</span><br>
 <span id=x143>… each operator should be tested separately, and on top of that, a set of models that exercise the API and run the results of the whole model</span><br>
@@ -211,7 +211,7 @@
 
 <address>Minutes manually created (not a transcript), formatted by <a
 href="https://w3c.github.io/scribe2/scribedoc.html"
->scribe.perl</a> version 228 (Tue Jul 23 12:57:54 2024 UTC).</address>
+>scribe.perl</a> version google-slides-232 (Wed Sep 18 23:49:16 2024 UTC).</address>
 
 <div class=diagnostics>
 <h2>Diagnostics</h2>

--- a/sample-team.html
+++ b/sample-team.html
@@ -746,7 +746,7 @@ HTML Working Group face-to-face meeting</h1>
 
 <address>Minutes manually created (not a transcript), formatted by <a
 href="https://w3c.github.io/scribe2/scribedoc.html"
->scribe.perl</a> version 228 (Tue Jul 23 12:57:54 2024 UTC).</address>
+>scribe.perl</a> version google-slides-232 (Wed Sep 18 23:49:16 2024 UTC).</address>
 
 <div class=diagnostics>
 <h2>Diagnostics</h2>

--- a/scribe.perl
+++ b/scribe.perl
@@ -174,7 +174,7 @@ my $stylesheet;			# URL of style sheet, undef = use defaults
 my $mathjax =			# undef = no math; string is MathJax URL
   'https://www.w3.org/scripts/MathJax/3/es5/mml-chtml.js';
 my $islide =			# String is i-slide library URL
-  'https://w3c.github.io/i-slide/i-slide.js?selector=a.islide';
+  'https://w3c.github.io/i-slide/i-slide-2.js?selector=a.islide';
 my $github = 1;			# If 0, don't make links for GitHub issues
 my $ghurlbot = 1;		# If 0, hide conversations with GHURLbot
 

--- a/scribe.perl
+++ b/scribe.perl
@@ -174,7 +174,7 @@ my $stylesheet;			# URL of style sheet, undef = use defaults
 my $mathjax =			# undef = no math; string is MathJax URL
   'https://www.w3.org/scripts/MathJax/3/es5/mml-chtml.js';
 my $islide =			# String is i-slide library URL
-  'https://w3c.github.io/i-slide/i-slide-2.js?selector=a.islide';
+  '../i-slide/i-slide.js?selector=a.islide';
 my $github = 1;			# If 0, don't make links for GitHub issues
 my $ghurlbot = 1;		# If 0, hide conversations with GHURLbot
 
@@ -1623,7 +1623,7 @@ my %linepat = (
   T => ["<h4 id=%2\$s>%3\$s%6\$s</h4>\n", 1],
   t => ["</section>\n\n<section>\n<h3 id=%2\$s>%3\$s%6\$s</h3>\n", 1],
   slideset => ["<p id=%5\$s class=summary>Slideset: %3\$s%7\$s</p>\n", 0],
-  slide => ["<p id=%5\$s class=summary><a class=islide data-islidesrcref=\"%7\$s\" href=\"%2\$s\">[Slide %3\$s]</a></p>\n", 1],
+  slide => ["<p id=%5\$s class=summary><a class=islide data-islide-srcref=\"%7\$s\" href=\"%2\$s\">[Slide %3\$s]</a></p>\n", 1],
   repo => ["<p id=%5\$s class=summary>Repository: %3\$s</p>\n", 0],
   drop => ["<p id=%5\$s class=summary>Repository- %3\$s</p>\n", 1],
     );

--- a/scribe.perl
+++ b/scribe.perl
@@ -174,7 +174,7 @@ my $stylesheet;			# URL of style sheet, undef = use defaults
 my $mathjax =			# undef = no math; string is MathJax URL
   'https://www.w3.org/scripts/MathJax/3/es5/mml-chtml.js';
 my $islide =			# String is i-slide library URL
-  '../i-slide/i-slide.js?selector=a.islide';
+  'https://w3c.github.io/i-slide/i-slide.js?selector=a.islide';
 my $github = 1;			# If 0, don't make links for GitHub issues
 my $ghurlbot = 1;		# If 0, hide conversations with GHURLbot
 
@@ -838,10 +838,10 @@ sub remove_repositories($)
 
 
 # Main body
-my $revision = '$Revision: 229 $'
+my $revision = '$Revision: google-slides-232 $'
   =~ s/\$Revision: //r
   =~ s/ \$//r;
-my $versiondate = '$Date: Thu Jul 25 08:38:54 2024 UTC $'
+my $versiondate = '$Date: Wed Sep 18 23:49:16 2024 UTC $'
   =~ s/\$Date: //r
   =~ s/ \$//r;
 
@@ -1653,7 +1653,7 @@ foreach my $p (@records) {
       $speakers{fc $p->{speaker}} // '',				    # %4
       ++$lineid,							    # %5
       link_to_recording($canonical_recording, $p->{time}),		    # %6
-      $p->{archive};                                                        # %7
+      $p->{archive} // '';						    # %7
   if (!$keeplines) {
     $line =~ tr/\t/ /;
   } elsif ($line =~ /\t/) {

--- a/tests/cont-10.test
+++ b/tests/cont-10.test
@@ -38,10 +38,10 @@ cat >$TMP4 <<EOF
 <span id=x004>… this continues the previous line</span></p>
 <p id=x007 class="phone s01"><cite>Ben:</cite> a link:<br>
 <span id=x008>… <a href="http://example.org/example">Example</a></span></p>
-<p id=x009 class=summary><a class=islide href="https://example.org/slides#4">[Slide 4]</a></p>
+<p id=x009 class=summary><a class=islide data-islide-srcref="" href="https://example.org/slides#4">[Slide 4]</a></p>
 <p id=x010 class="phone s01"><cite>Ben:</cite> this continues Ben's text</p>
 <p id=x011 class=summary>Everybody claps</p>
-<p id=x012 class=summary><a class=islide href="https://example.org/slides#5">[Slide 5]</a></p>
+<p id=x012 class=summary><a class=islide data-islide-srcref="" href="https://example.org/slides#5">[Slide 5]</a></p>
 <p id=x013 class=summary>This does not continue anything</p>
 <p id=x014 class=summary>Repository: w3c/test</p>
 <p id=x015 class=summary>Not a continuation.</p>

--- a/tests/slide-1.test
+++ b/tests/slide-1.test
@@ -17,6 +17,6 @@ EOF
 perl scribe.perl -embed $TMP1 >$TMP2 || exit 1
 cat $TMP2
 
-grep -E '<a class=islide href="https://example.org/#1">' $TMP2 || exit 1
-grep -E '<script type=module src="https://w3c.github.io/i-slide/i-slide-2.js\?selector=a\.islide' $TMP2 || exit 1
+grep -E '<a class=islide data-islide-srcref="" href="https://example.org/#1">' $TMP2 || exit 1
+grep -E '<script type=module src="https://w3c.github.io/i-slide/i-slide.js\?selector=a\.islide' $TMP2 || exit 1
 exit 0

--- a/tests/slide-2.test
+++ b/tests/slide-2.test
@@ -14,5 +14,5 @@ EOF
 perl scribe.perl -embed $TMP1 >$TMP2 || exit 1
 cat $TMP2
 
-grep -E '<a class=islide href="https://example.org/slides.pdf#page=1">' $TMP2 || exit 1
+grep -E '<a class=islide data-islide-srcref="" href="https://example.org/slides.pdf#page=1">' $TMP2 || exit 1
 exit 0

--- a/tests/slide-3.test
+++ b/tests/slide-3.test
@@ -19,7 +19,7 @@ perl scribe.perl -embed $TMP1 >$TMP2 || exit 1
 cat $TMP2
 
 grep -E '<a href="https://example.org/">A slideset</a>' $TMP2 || exit 1
-grep -E '<a class=islide href="https://example.org/#1">' $TMP2 || exit 1
-grep -E '<a class=islide href="https://example.net/#3">' $TMP2 || exit 1
+grep -E '<a class=islide data-islide-srcref="" href="https://example.org/#1">' $TMP2 || exit 1
+grep -E '<a class=islide data-islide-srcref="" href="https://example.net/#3">' $TMP2 || exit 1
 grep -E '>\[Slide 4\]</p>' $TMP2 || exit 1
 exit 0

--- a/tests/slide-4.test
+++ b/tests/slide-4.test
@@ -16,7 +16,7 @@ EOF
 perl scribe.perl -embed $TMP1 >$TMP2 || exit 1
 cat $TMP2
 
-grep -E '<a class=islide href="https://example.org/#1">' $TMP2 || exit 1
+grep -E '<a class=islide data-islide-srcref="" href="https://example.org/#1">' $TMP2 || exit 1
 grep -E ' class=summary>\[Slide 3\]</p>' $TMP2 || exit 1
 
 exit 0


### PR DESCRIPTION
This requires a pending new release of i-slide https://github.com/w3c/i-slide/pull/47

The way this works is that when scribe.perl identifies the URL of a Google slideset in the slideset command, it downloads the PDF export of that slideset, embeds it as a data URL in a download link (which has the benefit of archiving it in the state it was at the time where the minutes are generated) and annotates i-slide elements so that i-slide knows how to display them from the embedded data.

Since downloading the PDF takes more time than what is usually expected for running scribe.perl, it would be good to ensure this doesn't freeze RRSAgent when it does so.