### PR TITLE
ensure that *merged* PRs mentioned by ghurlbot are correctly presented

### DIFF
--- a/scribe.perl
+++ b/scribe.perl
@@ -1447,7 +1447,7 @@ for (my $i = 0; $i < @records; $i++) {
     $records[$i]->{type} = 'o';		# Ignore if --noghurlbot was set
 
   } elsif ($records[$i]->{speaker} =~ /^ghurlbot$|^gb$/ &&
-	   /^($urlpat) -> ((?:CLOSED )?(?:Issue |Action |Pull Request |Discussion |\#)[0-9]+) ?(.*)$/i) {
+	   /^($urlpat) -> ((?:CLOSED |MERGED )?(?:Issue |Action |Pull Request |Discussion |\#)[0-9]+) ?(.*)$/i) {
     $records[$i]->{type} = 'B';		# A structured response from ghurlbot
     $records[$i]->{data} = $3;
     $records[$i]->{text} = "->$1 $2";


### PR DESCRIPTION
currently, when ghurlbot mentions a merged PR, the regular expression does not catch it,
and so this mention appears as any regular IRC utterance